### PR TITLE
Corrected handler

### DIFF
--- a/pin.js
+++ b/pin.js
@@ -10,7 +10,7 @@ Pin.preload = function () {
 
   seneca.decorate('pin', api_pin)
 
-  seneca.once('ready', ()=> {
+  seneca.on('ready', () => {
     seneca.root.emit('pin')
     seneca.root.emit('after-pin')
   })


### PR DESCRIPTION
@mihaidma This should fix the issue in web. The problem is that there should be an equal amount of 'pin' and 'after-pin' emits as 'ready'.

See [here](https://github.com/senecajs/seneca/blob/b7e49e050983ee7cda602bdc71a1071f6a2a5653/seneca.js#L1925)

This change should correctly mimic the old logic.
